### PR TITLE
Make basal record validation more accurate

### DIFF
--- a/lib/parsers/basal.js
+++ b/lib/parsers/basal.js
@@ -22,16 +22,16 @@ module.exports = function configure (utils) {
 
   function isValid (data) {
     return (!isNaN(data.basal)
-      && data.basal > 0
+      && data.basal != ""
       && !isNaN(data.value)
-      && data.value > 0
+      && data.value != ""
       && data.start
       && data.basal_type
       && data.type == 'basal'
       );
   }
 
-  var pattern = /CurrentBasalProfile\b|BasalProfileStart/g;
+  var pattern = /BasalProfileStart/g;
   var stream = utils.pipeline(utils.split( ), utils.map(parse), utils.validator(isValid));
   var parser = { pattern: pattern, stream: stream, parse: parse };
   return parser;


### PR DESCRIPTION
0 rate basal records are perfectly valid.
If the rate is missing altogether, it's invalid.
