### PR TITLE
Changes to add annotations for mismatched settings

### DIFF
--- a/lib/carelink/misc.js
+++ b/lib/carelink/misc.js
@@ -1,3 +1,5 @@
+var _ = require('lodash');
+
 /**
  * Builds a function that can be applied to an observable to assert that messages
  * which meet the given predicate are ordered by uploadId -> seqNum
@@ -82,6 +84,31 @@ exports.invertSort = function(compareFn) {
   return function(lhs, rhs) {
     return -compareFn(lhs, rhs);
   }
-}
+};
+
+/**
+ * Adds an annotation to an event.
+ *
+ * @param event the event
+ * @param ann the opaque string code for the annotation to add, or the annotation object itself
+ */
+exports.annotateEvent = function(event, ann) {
+  if (event.annotations == null) {
+    event.annotations = [];
+  }
+
+  var annotation = typeof(ann) === 'string' ? { code: ann } : ann;
+  var exists = false;
+  for (var i = 0; i < event.annotations.length; ++i) {
+    if (_.isEqual(event.annotations[i], annotation)) {
+      exists = true;
+      break;
+    }
+  }
+
+  if (! exists) {
+    event.annotations.push(annotation);
+  }
+};
 
 

--- a/lib/carelink/settingsJoiner.js
+++ b/lib/carelink/settingsJoiner.js
@@ -403,10 +403,9 @@ function marrySettings(configFn) {
           },
           onLifecycleStart: function(e) {
             if (currSettings.activeBasalSchedule !== e.scheduleName) {
-              return err(
-                'activeBasalSchedule[%s] doesn\'t match [%s], ts[%s]',
-                e.previousSchedule, currSettings.activeBasalSchedule, e.deviceTime
-              );
+              currSettings.activeBasalSchedule = null;
+              this.onLifecycleEnd(e);
+              misc.annotateEvent(currSettings, 'settings-mismatch/activeSchedule');
             }
 
             currSettings.deviceTime = e.deviceTime;
@@ -426,7 +425,8 @@ function marrySettings(configFn) {
           },
           onLifecycleStart: function(e) {
             if (! this.isUpToDate(e)) {
-              err('bolusWizards don\'t match, ts[%s]', e.deviceTime);
+              this.onLifecycleEnd(e);
+              misc.annotateEvent(currSettings, 'settings-mismatch/wizard');
             }
             currSettings.deviceTime = e.deviceTime;
             return currSettings;
@@ -444,9 +444,10 @@ function marrySettings(configFn) {
           },
           onLifecycleStart: function(e) {
             if (! _.isEqual(currSettings.basalSchedules[e.scheduleName], e.payload)) {
-              err('Schedules[%s] no match at ts[%s]', e.scheduleName, e.deviceTime);
-              return null;
+              this.onLifecycleEnd(e);
+              misc.annotateEvent(currSettings, 'settings-mismatch/basal');
             }
+
             currSettings.deviceTime = e.deviceTime;
             var retVal = currSettings;
 


### PR DESCRIPTION
When a pump gets reset, it loses continuity in the flow of the settings, which causes the validity checks that were in place to fail.  This fix changes it so that instead of failing, we assume the new data is good and annotate the event (and all subsequent events as the change will cascade) that we are making an assumption.

The intent is that this annotation will be visible on each datum such that it can be exposed in a visualization.  @kentquirk lmk what you think.
